### PR TITLE
remove authentication/pagination/endpoint methods from core

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ jobs:
         - sleep 3 # give xvfb some time to start
         # do actual tests
         - npm run test
-        - npm run test:browser
+        - travis_retry npm run test:browser
         - npm run coverage:upload
         - npm run validate:ts
     # release stage: run semantic release & update the docs

--- a/README.md
+++ b/README.md
@@ -18,6 +18,31 @@ This fork is work-in-progress exploration towards [Browser Support for `@octokit
    const octokit = new Octokit()
    ```
 
+## Breaking changes
+
+The endpoint methods like `octokit.repos.get()` are generated from the
+[lib/routes.json](lib/routes.json) file, which is used. The internal
+implementation already moved it into a plugin so we take advantage of that now.
+Instead of loading these plugins by default:
+
+- [authentication](lib/plugins/authentication)
+- [endpoint-methods](lib/plugins/endpoint-methods)
+- [pagination](lib/plugins/pagination)
+
+You will now have to load them manually, like so
+
+```js
+const octokit = require('@gr2m/octokit-rest-browser-experimental')()
+// add octokit.authenticate() method
+octokit.plugin(require('@gr2m/octokit-rest-browser-experimental/lib/plugins/authentication'))
+
+// add endpoint methods
+octokit.plugin(require('@gr2m/octokit-rest-browser-experimental/lib/plugins/endpoint-methods'))
+
+// add pagination methods
+octokit.plugin(require('@gr2m/octokit-rest-browser-experimental/lib/plugins/pagination'))
+```
+
 ## Testing with Puppeteer
 
 [Puppeteer](https://github.com/GoogleChrome/puppeteer) is library to control a

--- a/index.js
+++ b/index.js
@@ -7,12 +7,6 @@ const parseClientOptions = require('./lib/parse-client-options')
 const request = require('./lib/request')
 const ENDPOINT_DEFAULTS = require('./lib/endpoint').DEFAULTS
 
-const PLUGINS = [
-  require('./lib/plugins/authentication'),
-  require('./lib/plugins/endpoint-methods'),
-  require('./lib/plugins/pagination')
-]
-
 function GitHubApi (options) {
   const defaults = defaultsDeep(parseClientOptions(options), ENDPOINT_DEFAULTS)
 
@@ -24,8 +18,6 @@ function GitHubApi (options) {
     plugin: (pluginFunction) => pluginFunction(api),
     request: (options) => api.hook('request', defaultsDeep(options, defaults), request)
   }
-
-  PLUGINS.forEach(api.plugin)
 
   return api
 }

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
   "standard": {
     "globals": [
       "describe",
+      "beforeEach",
       "it"
     ]
   }

--- a/test/integration/authentication-test.js
+++ b/test/integration/authentication-test.js
@@ -6,6 +6,16 @@ const GitHub = require('../../')
 chai.should()
 
 describe('authentication', () => {
+  let github
+
+  beforeEach(() => {
+    github = new GitHub({
+      host: 'authentication-test-host.com'
+    })
+    github.plugin(require('../../lib/plugins/endpoint-methods'))
+    github.plugin(require('../../lib/plugins/authentication'))
+  })
+
   it('basic', () => {
     nock('https://authentication-test-host.com', {
       reqheaders: {
@@ -14,10 +24,6 @@ describe('authentication', () => {
     })
       .get('/orgs/myorg')
       .reply(200, {})
-
-    const github = new GitHub({
-      host: 'authentication-test-host.com'
-    })
 
     github.authenticate({
       type: 'basic',
@@ -37,10 +43,6 @@ describe('authentication', () => {
       .get('/orgs/myorg')
       .reply(200, {})
 
-    const github = new GitHub({
-      host: 'authentication-test-host.com'
-    })
-
     github.authenticate({
       type: 'token',
       token: 'abc4567'
@@ -54,10 +56,6 @@ describe('authentication', () => {
       .get('/orgs/myorg')
       .query({access_token: 'abc4567'})
       .reply(200, {})
-
-    const github = new GitHub({
-      host: 'authentication-test-host.com'
-    })
 
     github.authenticate({
       type: 'oauth',
@@ -73,10 +71,6 @@ describe('authentication', () => {
       .query({per_page: 1, access_token: 'abc4567'})
       .reply(200, [])
 
-    const github = new GitHub({
-      host: 'authentication-test-host.com'
-    })
-
     github.authenticate({
       type: 'oauth',
       token: 'abc4567'
@@ -90,10 +84,6 @@ describe('authentication', () => {
       .get('/orgs/myorg')
       .query({client_id: 'oauthkey', client_secret: 'oauthsecret'})
       .reply(200, {})
-
-    const github = new GitHub({
-      host: 'authentication-test-host.com'
-    })
 
     github.authenticate({
       type: 'oauth',
@@ -109,10 +99,6 @@ describe('authentication', () => {
       .get('/orgs/myorg/repos')
       .query({per_page: 1, client_id: 'oauthkey', client_secret: 'oauthsecret'})
       .reply(200, [])
-
-    const github = new GitHub({
-      host: 'authentication-test-host.com'
-    })
 
     github.authenticate({
       type: 'oauth',
@@ -132,10 +118,6 @@ describe('authentication', () => {
       .get('/orgs/myorg')
       .reply(200, {})
 
-    const github = new GitHub({
-      host: 'authentication-test-host.com'
-    })
-
     github.authenticate({
       type: 'integration',
       token: 'abc4567'
@@ -145,17 +127,10 @@ describe('authentication', () => {
   })
 
   it('authenticate without options', () => {
-    const github = new GitHub({
-      host: 'authentication-test-host.com'
-    })
     github.authenticate()
   })
 
   it('authenticate errors', () => {
-    const github = new GitHub({
-      host: 'authentication-test-host.com'
-    })
-
     ;(() => {
       github.authenticate({})
     }).should.throw(Error)

--- a/test/integration/conditional-request-test.js
+++ b/test/integration/conditional-request-test.js
@@ -6,14 +6,19 @@ const GitHub = require('../../')
 chai.should()
 
 describe('request 304s', () => {
+  let github
+
+  beforeEach(() => {
+    github = new GitHub({
+      host: 'request-errors-test.com'
+    })
+    github.plugin(require('../../lib/plugins/endpoint-methods'))
+  })
+
   it('304 etag', () => {
     nock('https://request-errors-test.com')
       .get('/orgs/myorg')
       .reply(304, '')
-
-    const github = new GitHub({
-      host: 'request-errors-test.com'
-    })
 
     return github.orgs.get({org: 'myorg', headers: {'If-None-Match': 'etag'}})
 
@@ -25,10 +30,6 @@ describe('request 304s', () => {
     nock('https://request-errors-test.com')
       .get('/orgs/myorg')
       .reply(304, '')
-
-    const github = new GitHub({
-      host: 'request-errors-test.com'
-    })
 
     return github.orgs.get({org: 'myorg', headers: {'If-Modified-Since': 'Sun Dec 24 2017 22:00:00 GMT-0600 (CST)'}})
 

--- a/test/integration/deprecations-test.js
+++ b/test/integration/deprecations-test.js
@@ -7,15 +7,21 @@ const GitHub = require('../../')
 chai.should()
 
 describe('deprecations', () => {
+  let github
+
+  beforeEach(() => {
+    github = new GitHub({
+      host: 'deprecations-test.com'
+    })
+    github.plugin(require('../../lib/plugins/endpoint-methods'))
+  })
+
   it('github.integrations.*', () => {
     simple.mock(console, 'warn', () => {})
     nock('https://deprecations-test.com')
       .get('/app/installations')
       .reply(200, [])
 
-    const github = new GitHub({
-      host: 'deprecations-test.com'
-    })
     return github.integrations.getInstallations({})
 
     .then(() => {

--- a/test/integration/experimentals-test.js
+++ b/test/integration/experimentals-test.js
@@ -6,15 +6,20 @@ const GitHub = require('../../')
 chai.should()
 
 describe('authentication plugin', () => {
+  let github
+
+  beforeEach(() => {
+    github = new GitHub({
+      host: 'authentication-plugin-test-host.com'
+    })
+    github.plugin(require('../../lib/plugins/authentication'))
+  })
+
   it('OAuth authentication with URL containing ?', () => {
     nock('https://authentication-plugin-test-host.com')
       .get('/')
       .query({foo: 'bar', client_id: 'oauthkey', client_secret: 'oauthsecret'})
       .reply(200, {})
-
-    const github = new GitHub({
-      host: 'authentication-plugin-test-host.com'
-    })
 
     github.authenticate({
       type: 'oauth',

--- a/test/integration/params-validations-test.js
+++ b/test/integration/params-validations-test.js
@@ -8,6 +8,7 @@ chai.should()
 describe('params validations', () => {
   it('github.orgs.get({})', () => {
     const github = new GitHub()
+    github.plugin(require('../../lib/plugins/endpoint-methods'))
 
     return github.orgs.get({})
 
@@ -26,6 +27,7 @@ describe('params validations', () => {
       host: '127.0.0.1',
       port: 8 // officially unassigned port. See https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers
     })
+    github.plugin(require('../../lib/plugins/endpoint-methods'))
 
     return github.orgs.get({org: 'foo'})
 
@@ -40,6 +42,7 @@ describe('params validations', () => {
 
   it('invalid value for github.issues.getAll({filter})', () => {
     const github = new GitHub()
+    github.plugin(require('../../lib/plugins/endpoint-methods'))
 
     return github.issues.getAll({filter: 'foo'})
 
@@ -54,6 +57,7 @@ describe('params validations', () => {
 
   it('invalid value for github.projects.moveProjectCard({position})', () => {
     const github = new GitHub()
+    github.plugin(require('../../lib/plugins/endpoint-methods'))
 
     return github.projects.moveProjectCard({id: 123, position: 'foo'})
 
@@ -68,6 +72,7 @@ describe('params validations', () => {
 
   it('Not a number for github.repos.createCommitComment({..., position})', () => {
     const github = new GitHub()
+    github.plugin(require('../../lib/plugins/endpoint-methods'))
 
     return github.repos.createCommitComment({
       owner: 'foo',
@@ -88,6 +93,7 @@ describe('params validations', () => {
 
   it('Not a valid JSON string for github.repos.createHook({..., config})', () => {
     const github = new GitHub()
+    github.plugin(require('../../lib/plugins/endpoint-methods'))
 
     return github.repos.createHook({
       owner: 'foo',
@@ -109,6 +115,7 @@ describe('params validations', () => {
     const github = new GitHub({
       host: 'milestones-test-host.com'
     })
+    github.plugin(require('../../lib/plugins/endpoint-methods'))
 
     nock('https://milestones-test-host.com')
       .post('/repos/foo/bar/milestones', (body) => {
@@ -129,6 +136,7 @@ describe('params validations', () => {
     const github = new GitHub({
       host: 'notifications-test-host.com'
     })
+    github.plugin(require('../../lib/plugins/endpoint-methods'))
 
     nock('https://notifications-test-host.com')
       .get('/notifications')

--- a/test/integration/release-assets-buffer-test.js
+++ b/test/integration/release-assets-buffer-test.js
@@ -10,16 +10,22 @@ const it = mocha.it
 chai.should()
 
 describe('api.github.com', () => {
+  let github
+
+  beforeEach(() => {
+    github = new GitHub()
+    github.plugin(require('../../lib/plugins/authentication'))
+    github.plugin(require('../../lib/plugins/endpoint-methods'))
+  })
+
   it('github.repos.uploadAsset as Buffer', () => {
     fixtures.mock('api.github.com/release-assets')
-    const githubUserA = new GitHub()
-
-    githubUserA.authenticate({
+    github.authenticate({
       type: 'token',
       token: '0000000000000000000000000000000000000001'
     })
 
-    return githubUserA.repos.getReleaseByTag({
+    return github.repos.getReleaseByTag({
       owner: 'octokit-fixture-org',
       repo: 'release-assets',
       tag: 'v1.0.0'
@@ -27,7 +33,7 @@ describe('api.github.com', () => {
 
     .then(result => {
       const content = Buffer.from('Hello, world!\n')
-      return githubUserA.repos.uploadAsset({
+      return github.repos.uploadAsset({
         url: result.data.upload_url,
         file: content,
         contentType: 'text/plain',
@@ -40,14 +46,13 @@ describe('api.github.com', () => {
 
   it('github.repos.uploadAsset as ArrayBuffer', () => {
     fixtures.mock('api.github.com/release-assets')
-    const githubUserA = new GitHub()
 
-    githubUserA.authenticate({
+    github.authenticate({
       type: 'token',
       token: '0000000000000000000000000000000000000001'
     })
 
-    return githubUserA.repos.getReleaseByTag({
+    return github.repos.getReleaseByTag({
       owner: 'octokit-fixture-org',
       repo: 'release-assets',
       tag: 'v1.0.0'
@@ -55,7 +60,7 @@ describe('api.github.com', () => {
 
     .then(result => {
       const content = stringToArrayBuffer('Hello, world!\n')
-      return githubUserA.repos.uploadAsset({
+      return github.repos.uploadAsset({
         url: result.data.upload_url,
         file: content,
         contentType: 'text/plain',

--- a/test/integration/request-errors-test.js
+++ b/test/integration/request-errors-test.js
@@ -16,6 +16,7 @@ describe('request errors', () => {
       host: 'request-errors-test.com',
       timeout: 1000
     })
+    github.plugin(require('../../lib/plugins/endpoint-methods'))
 
     return github.orgs.get({org: 'myorg'})
 
@@ -30,9 +31,9 @@ describe('request errors', () => {
       .replyWithError('ooops')
 
     const github = new GitHub({
-      host: 'request-errors-test.com',
-      timeout: 1000
+      host: 'request-errors-test.com'
     })
+    github.plugin(require('../../lib/plugins/endpoint-methods'))
 
     return github.orgs.get({org: 'myorg'})
 

--- a/test/integration/smoke-test.js
+++ b/test/integration/smoke-test.js
@@ -21,6 +21,8 @@ describe('smoke', () => {
       pathPrefix: '/my/api/'
     })
 
+    github.plugin(require('../../lib/plugins/endpoint-methods'))
+
     return github.orgs.get({org: 'myorg'})
   })
 
@@ -33,6 +35,8 @@ describe('smoke', () => {
       host: 'smoke-test.com'
     })
 
+    github.plugin(require('../../lib/plugins/endpoint-methods'))
+
     github.orgs.get({org: 'myorg'}, done)
   })
 
@@ -44,6 +48,8 @@ describe('smoke', () => {
     const github = new GitHub({
       host: 'smoke-test.com'
     })
+
+    github.plugin(require('../../lib/plugins/endpoint-methods'))
 
     const customHeaders = {
       'User-Agent': 'blah'
@@ -81,6 +87,10 @@ describe('smoke', () => {
     const github = new GitHub({
       host: 'smoke-test.com'
     })
+
+    github.plugin(require('../../lib/plugins/authentication'))
+    github.plugin(require('../../lib/plugins/endpoint-methods'))
+    github.plugin(require('../../lib/plugins/pagination'))
 
     github.authenticate({
       type: 'token',

--- a/test/scenarios/add-and-remove-repository-collaborator-test.js
+++ b/test/scenarios/add-and-remove-repository-collaborator-test.js
@@ -15,6 +15,11 @@ describe('api.github.com', () => {
       host: 'localhost:3000'
     })
 
+    githubUserA.plugin(require('../../lib/plugins/authentication'))
+    githubUserA.plugin(require('../../lib/plugins/endpoint-methods'))
+    githubUserB.plugin(require('../../lib/plugins/authentication'))
+    githubUserB.plugin(require('../../lib/plugins/endpoint-methods'))
+
     githubUserA.authenticate({
       type: 'token',
       token: '0000000000000000000000000000000000000001'

--- a/test/scenarios/add-labels-to-issue-test.js
+++ b/test/scenarios/add-labels-to-issue-test.js
@@ -6,17 +6,19 @@ chai.should()
 
 describe('api.github.com', () => {
   it('(#587) add-labels-to-issue-test', () => {
-    const githubUserA = new GitHub({
+    const github = new GitHub({
       protocol: 'http',
       host: 'localhost:3000'
     })
+    github.plugin(require('../../lib/plugins/authentication'))
+    github.plugin(require('../../lib/plugins/endpoint-methods'))
 
-    githubUserA.authenticate({
+    github.authenticate({
       type: 'token',
       token: '0000000000000000000000000000000000000001'
     })
 
-    return githubUserA.issues.create({
+    return github.issues.create({
       owner: 'octokit-fixture-org',
       repo: 'add-labels-to-issue',
       title: 'Issue without a label',
@@ -27,7 +29,7 @@ describe('api.github.com', () => {
     })
 
     .then(() => {
-      return githubUserA.issues.addLabels({
+      return github.issues.addLabels({
         owner: 'octokit-fixture-org',
         repo: 'add-labels-to-issue',
         number: 1,

--- a/test/scenarios/branch-protection-test.js
+++ b/test/scenarios/branch-protection-test.js
@@ -10,6 +10,8 @@ describe('api.github.com', () => {
       protocol: 'http',
       host: 'localhost:3000'
     })
+    github.plugin(require('../../lib/plugins/authentication'))
+    github.plugin(require('../../lib/plugins/endpoint-methods'))
 
     github.authenticate({
       type: 'token',

--- a/test/scenarios/create-file-test.js
+++ b/test/scenarios/create-file-test.js
@@ -11,6 +11,8 @@ describe('api.github.com', () => {
       protocol: 'http',
       host: 'localhost:3000'
     })
+    github.plugin(require('../../lib/plugins/authentication'))
+    github.plugin(require('../../lib/plugins/endpoint-methods'))
 
     github.authenticate({
       type: 'token',

--- a/test/scenarios/create-status-test.js
+++ b/test/scenarios/create-status-test.js
@@ -10,6 +10,8 @@ describe('api.github.com', () => {
       protocol: 'http',
       host: 'localhost:3000'
     })
+    github.plugin(require('../../lib/plugins/authentication'))
+    github.plugin(require('../../lib/plugins/endpoint-methods'))
 
     github.authenticate({
       type: 'token',

--- a/test/scenarios/get-content-test.js
+++ b/test/scenarios/get-content-test.js
@@ -10,6 +10,7 @@ describe('api.github.com', () => {
       protocol: 'http',
       host: 'localhost:3000'
     })
+    github.plugin(require('../../lib/plugins/endpoint-methods'))
 
     return github.repos.getContent({owner: 'octokit-fixture-org', repo: 'hello-world', path: ''})
 

--- a/test/scenarios/get-organization-test.js
+++ b/test/scenarios/get-organization-test.js
@@ -10,6 +10,7 @@ describe('api.github.com', () => {
       protocol: 'http',
       host: 'localhost:3000'
     })
+    github.plugin(require('../../lib/plugins/endpoint-methods'))
 
     return github.orgs.get({org: 'octokit-fixture-org'})
 

--- a/test/scenarios/get-repository-test.js
+++ b/test/scenarios/get-repository-test.js
@@ -11,6 +11,8 @@ describe('api.github.com', () => {
       host: 'localhost:3000'
     })
 
+    github.plugin(require('../../lib/plugins/endpoint-methods'))
+
     return github.repos.get({
       owner: 'octokit-fixture-org',
       repo: 'hello-world',

--- a/test/scenarios/git-refs-test.js
+++ b/test/scenarios/git-refs-test.js
@@ -6,23 +6,26 @@ chai.should()
 
 describe('api.github.com', () => {
   it('github.gitdata.*', () => {
-    const githubUserA = new GitHub({
+    const github = new GitHub({
       protocol: 'http',
       host: 'localhost:3000'
     })
 
-    githubUserA.authenticate({
+    github.plugin(require('../../lib/plugins/authentication'))
+    github.plugin(require('../../lib/plugins/endpoint-methods'))
+
+    github.authenticate({
       type: 'token',
       token: '0000000000000000000000000000000000000001'
     })
 
-    return githubUserA.gitdata.getReferences({
+    return github.gitdata.getReferences({
       owner: 'octokit-fixture-org',
       repo: 'git-refs'
     })
 
     .then(() => {
-      return githubUserA.gitdata.createReference({
+      return github.gitdata.createReference({
         owner: 'octokit-fixture-org',
         repo: 'git-refs',
         ref: 'refs/heads/test',
@@ -31,7 +34,7 @@ describe('api.github.com', () => {
     })
 
     .then(() => {
-      return githubUserA.gitdata.updateReference({
+      return github.gitdata.updateReference({
         owner: 'octokit-fixture-org',
         repo: 'git-refs',
         ref: 'heads/test',
@@ -40,14 +43,14 @@ describe('api.github.com', () => {
     })
 
     .then(() => {
-      return githubUserA.gitdata.getReferences({
+      return github.gitdata.getReferences({
         owner: 'octokit-fixture-org',
         repo: 'git-refs'
       })
     })
 
     .then(() => {
-      return githubUserA.gitdata.deleteReference({
+      return github.gitdata.deleteReference({
         owner: 'octokit-fixture-org',
         repo: 'git-refs',
         ref: 'heads/test'

--- a/test/scenarios/labels-test.js
+++ b/test/scenarios/labels-test.js
@@ -5,17 +5,20 @@ chai.should()
 
 describe('api.github.com', () => {
   it('github.issues.*', () => {
-    const githubUserA = new GitHub({
+    const github = new GitHub({
       protocol: 'http',
       host: 'localhost:3000'
     })
 
-    githubUserA.authenticate({
+    github.plugin(require('../../lib/plugins/authentication'))
+    github.plugin(require('../../lib/plugins/endpoint-methods'))
+
+    github.authenticate({
       type: 'token',
       token: '0000000000000000000000000000000000000001'
     })
 
-    return githubUserA.issues.getLabels({
+    return github.issues.getLabels({
       owner: 'octokit-fixture-org',
       repo: 'labels'
     })
@@ -23,7 +26,7 @@ describe('api.github.com', () => {
     .then((result) => {
       result.data.should.be.an('array')
 
-      return githubUserA.issues.createLabel({
+      return github.issues.createLabel({
         owner: 'octokit-fixture-org',
         repo: 'labels',
         name: 'test-label',
@@ -34,7 +37,7 @@ describe('api.github.com', () => {
     .then((result) => {
       result.data.name.should.equal('test-label')
 
-      return githubUserA.issues.getLabel({
+      return github.issues.getLabel({
         owner: 'octokit-fixture-org',
         repo: 'labels',
         name: 'test-label'
@@ -42,7 +45,7 @@ describe('api.github.com', () => {
     })
 
     .then(() => {
-      return githubUserA.issues.updateLabel({
+      return github.issues.updateLabel({
         owner: 'octokit-fixture-org',
         repo: 'labels',
         oldname: 'test-label',
@@ -54,7 +57,7 @@ describe('api.github.com', () => {
     .then((result) => {
       result.data.name.should.equal('test-label-updated')
 
-      return githubUserA.issues.deleteLabel({
+      return github.issues.deleteLabel({
         owner: 'octokit-fixture-org',
         repo: 'labels',
         name: 'test-label-updated'

--- a/test/scenarios/lock-issue-test.js
+++ b/test/scenarios/lock-issue-test.js
@@ -11,6 +11,9 @@ describe('api.github.com', () => {
       host: 'localhost:3000'
     })
 
+    github.plugin(require('../../lib/plugins/authentication'))
+    github.plugin(require('../../lib/plugins/endpoint-methods'))
+
     github.authenticate({
       type: 'token',
       token: '0000000000000000000000000000000000000001'

--- a/test/scenarios/markdown-test.js
+++ b/test/scenarios/markdown-test.js
@@ -11,6 +11,8 @@ describe('api.github.com', () => {
       host: 'localhost:3000'
     })
 
+    github.plugin(require('../../lib/plugins/endpoint-methods'))
+
     return github.misc.renderMarkdown({
       text: `### Hello
 

--- a/test/scenarios/project-cards-test.js
+++ b/test/scenarios/project-cards-test.js
@@ -11,6 +11,9 @@ describe('api.github.com', () => {
       host: 'localhost:3000'
     })
 
+    github.plugin(require('../../lib/plugins/authentication'))
+    github.plugin(require('../../lib/plugins/endpoint-methods'))
+
     github.authenticate({
       type: 'token',
       token: '0000000000000000000000000000000000000001'

--- a/test/scenarios/release-assets-test.js
+++ b/test/scenarios/release-assets-test.js
@@ -7,20 +7,23 @@ chai.should()
 describe('api.github.com', () => {
   // @todo github.repos.uploadAsset is not working due to change of host in fixtures
   it.skip('github.repos.*Assets', () => {
-    const githubUserA = new GitHub({
+    const github = new GitHub({
       protocol: 'http',
       host: 'localhost:3000'
     })
 
+    github.plugin(require('../../lib/plugins/authentication'))
+    github.plugin(require('../../lib/plugins/endpoint-methods'))
+
     var releaseId
     var assetId
 
-    githubUserA.authenticate({
+    github.authenticate({
       type: 'token',
       token: '0000000000000000000000000000000000000001'
     })
 
-    return githubUserA.repos.getReleaseByTag({
+    return github.repos.getReleaseByTag({
       owner: 'octokit-fixture-org',
       repo: 'release-assets',
       tag: 'v1.0.0'
@@ -29,7 +32,7 @@ describe('api.github.com', () => {
     .then(result => {
       releaseId = result.data.id
 
-      return githubUserA.repos.uploadAsset({
+      return github.repos.uploadAsset({
         url: result.data.upload_url,
         file: 'Hello, world!\n',
         contentType: 'text/plain',
@@ -42,7 +45,7 @@ describe('api.github.com', () => {
     .then(result => {
       assetId = releaseId
 
-      return githubUserA.repos.getAssets({
+      return github.repos.getAssets({
         owner: 'octokit-fixture-org',
         repo: 'release-assets',
         id: releaseId
@@ -50,7 +53,7 @@ describe('api.github.com', () => {
     })
 
     .then(result => {
-      return githubUserA.repos.getAsset({
+      return github.repos.getAsset({
         owner: 'octokit-fixture-org',
         repo: 'release-assets',
         id: assetId
@@ -58,7 +61,7 @@ describe('api.github.com', () => {
     })
 
     .then(result => {
-      return githubUserA.repos.editAsset({
+      return github.repos.editAsset({
         owner: 'octokit-fixture-org',
         repo: 'release-assets',
         id: assetId,
@@ -68,7 +71,7 @@ describe('api.github.com', () => {
     })
 
     .then(result => {
-      return githubUserA.repos.deleteAsset({
+      return github.repos.deleteAsset({
         owner: 'octokit-fixture-org',
         repo: 'release-assets',
         id: assetId

--- a/test/scenarios/rename-repository-test.js
+++ b/test/scenarios/rename-repository-test.js
@@ -12,6 +12,9 @@ describe('api.github.com', () => {
       host: 'localhost:3000'
     })
 
+    github.plugin(require('../../lib/plugins/authentication'))
+    github.plugin(require('../../lib/plugins/endpoint-methods'))
+
     github.authenticate({
       type: 'token',
       token: '0000000000000000000000000000000000000001'

--- a/test/scenarios/search-issues-test.js
+++ b/test/scenarios/search-issues-test.js
@@ -6,17 +6,20 @@ chai.should()
 
 describe('api.github.com', () => {
   it('github.search.issues({q: "sesame repo:octokit-fixture-org/search-issues"})', () => {
-    const githubUserA = new GitHub({
+    const github = new GitHub({
       protocol: 'http',
       host: 'localhost:3000'
     })
 
-    githubUserA.authenticate({
+    github.plugin(require('../../lib/plugins/authentication'))
+    github.plugin(require('../../lib/plugins/endpoint-methods'))
+
+    github.authenticate({
       type: 'token',
       token: '0000000000000000000000000000000000000001'
     })
 
-    return githubUserA.search.issues({q: 'sesame repo:octokit-fixture-org/search-issues'})
+    return github.search.issues({q: 'sesame repo:octokit-fixture-org/search-issues'})
 
     .then((response) => {
       response.data.total_count.should.equal(2)

--- a/test/unit/upload-asset-test.js
+++ b/test/unit/upload-asset-test.js
@@ -12,6 +12,8 @@ describe('github.repos.uploadAsset', () => {
     const github = new GitHub()
     const size = fs.statSync(__filename).size
 
+    github.plugin(require('../../lib/plugins/endpoint-methods'))
+
     nock('https://upload.test')
       .post('/', function (data) {
         return fs.readFileSync(__filename, 'utf8') === data


### PR DESCRIPTION
load them via plugins. This is eventually going to happen in `@octokit/rest`, too. I’m doing it now to explore options to reduce bundle size